### PR TITLE
007 - Hotfix - creep allocation to sources

### DIFF
--- a/SpawnManager.py
+++ b/SpawnManager.py
@@ -66,30 +66,25 @@ def SpawnReichsprotektor (spawn):
 def create_transporter(room_capacity):
     modules = []
     if room_capacity == 300:
-        modules = [CARRY, CARRY, MOVE, MOVE]
+        modules = [CARRY, CARRY, CARRY, MOVE, MOVE, MOVE]
     else:
         # The amount of carry = amount of carry on a miner * 2
         # each full set of parts costs 2 move = 100 + 2 carry = 100, sum = 200.
         # But these are adjusted to miner carry *2, so I'm only spending 200 per 300 available energy.
-        # full_sets = int(room_capacity/300)
-        # for i in range(int(room_capacity/300)): #int rounds down
-        #     modules.append(CARRY)
-        #     modules.append(CARRY)
-        #     modules.append(MOVE)
-        #     modules.append(MOVE)
-        # if (room_capacity - (full_sets * 300)) >=200:
-        #     modules.append(MOVE)
-        #     modules.append(CARRY)
+        full_sets = int(room_capacity/100)
+        for i in range(int(room_capacity/100)): #int rounds down
+            modules.append(CARRY)
+            modules.append(MOVE)
 
         # V2: (assumes roads)
-            full_sets = int(room_capacity/150)
-            for i in range(full_sets): #int rounds down
-                modules.append(CARRY)
-                modules.append(CARRY)
-                modules.append(MOVE)
-            if (room_capacity - (full_sets * 150)) == 100:
-                modules.append(MOVE)
-                modules.append(CARRY)
+            # full_sets = int(room_capacity/150)
+            # for i in range(full_sets): #int rounds down
+            #     modules.append(CARRY)
+            #     modules.append(CARRY)
+            #     modules.append(MOVE)
+            # if (room_capacity - (full_sets * 150)) == 100:
+            #     modules.append(MOVE)
+            #     modules.append(CARRY)
     modules.sort()
     return modules
 

--- a/Strategy.py
+++ b/Strategy.py
@@ -42,6 +42,7 @@ def DetermineGamePhase (location):
             location.memory.remoteMining = False
             location.memory.scoutNeeded = False
             location.memory.TransportersPerAccesPoint = 1
+            location.memory.MaxHarversPerSource = 2
 
         # If at the start of the game and not enough extensions have been made:
         elif _.sum(location.find(FIND_STRUCTURES).filter(lambda s: s.structureType == STRUCTURE_EXTENSION)) <5 and _.sum(location.find(FIND_STRUCTURES).filter(lambda s: s.structureType == STRUCTURE_CONTAINER)) < 2:
@@ -51,6 +52,7 @@ def DetermineGamePhase (location):
             location.memory.remoteMining = False
             location.memory.scoutNeeded = False
             location.memory.TransportersPerAccesPoint = 1
+            location.memory.MaxHarversPerSource = 2
 
         elif location.controller.level <3:
             location.memory.GamePhase = 'GameStart'
@@ -59,6 +61,7 @@ def DetermineGamePhase (location):
             location.memory.remoteMining = False
             location.memory.scoutNeeded = False
             location.memory.TransportersPerAccesPoint = 1
+            location.memory.MaxHarversPerSource = 2
 
         elif _.sum(location.find(FIND_STRUCTURES).filter(lambda s: s.structureType == STRUCTURE_EXTENSION)) >8 and _.sum(location.find(FIND_STRUCTURES).filter(lambda s: s.structureType == STRUCTURE_CONTAINER)) > 1:
             # Add filter to ensure the number of rooms < maximum number of rooms.
@@ -68,6 +71,7 @@ def DetermineGamePhase (location):
             location.memory.remoteMining = False
             location.memory.scoutNeeded = False
             location.memory.TransportersPerAccesPoint = 1
+            location.memory.MaxHarversPerSource = 1
         else:
             location.memory.GamePhase = 'Debug'
             location.memory.minersPerAccessPoint = 0
@@ -144,12 +148,13 @@ def RoomEnergyIdentifier (location):
                 # terrain = 0 means plains.
                 # The and statement here is clunky but it works
                 # print('Terrain at X: ' + str(newX) + ' Y: ' + str(newY) + ' ' + str(terrain.get (newX, newY)))
-                if terrain.get(newX,newY) == 0 :
+                if terrain.get(newX,newY) == 0 or terrain.get(newX,newY) == 2:
                 # Nice code to disable seeing the source itself, not needed because sources are in walls:
                 # and source.pos.x != newX and source.pos.y != newY:
                     # print('Terrain at X: ' + str(newX) + ' Y: ' + str(newY) + ' ' + str(terrain.get (newX, newY)) + ' was considered an access point' )
-                    accessPoints = accessPoints + 1
-        totalAccesPoints = totalAccesPoints + min(accessPoints, location.memory.MaxHarversPerSource)
+                    accessPoints = min(accessPoints + 1, location.memory.MaxHarversPerSource)
+                    # print('We now have this many access points: ' + str(accessPoints))
+        totalAccesPoints = totalAccesPoints + accessPoints
         listForSourceData.append([source, accessPoints])
     # print (listForSourceData)
     location.memory.totalAccesPoints = totalAccesPoints
@@ -200,7 +205,7 @@ def assignSameRoomSource (location):
     # print(location.memory.sourceAccessability[0],location.memory.sourceAccessability[1],location.memory.sourceAccessability[0][0],location.memory.sourceAccessability[0][1])
     for i in range(len(location.memory.sourceAccessability)):
         source = location.memory.sourceAccessability[i][0]
-        requiredCreeps = min(2,location.memory.sourceAccessability[i][1] * location.memory.minersPerAccessPoint)
+        requiredCreeps = min(2,location.memory.sourceAccessability[i][1]) * location.memory.minersPerAccessPoint
 
         num_creeps = len(location.find(FIND_CREEPS).filter(lambda c: c.memory.source == source.id and len(c.memory.source)>0))
         print('Source: ', str(source.id) + ', requiredCreeps: ' + str(requiredCreeps) + ' num_creeps ' + str(num_creeps))
@@ -220,7 +225,7 @@ def assignSameRoomPickupPoint (location):
     print('attemping to assign source for location')
     for i in range(len(location.memory.sourceAccessability)):
         source = location.memory.sourceAccessability[i][0]
-        requiredCreeps = location.memory.sourceAccessability[i][1] * location.memory.TransportersPerAccesPoint
+        requiredCreeps =  min(location.memory.MaxHarversPerSource, location.memory.sourceAccessability[i][1]) * location.memory.TransportersPerAccesPoint
 
         num_creeps = len(location.find(FIND_CREEPS).filter(lambda c: c.memory.PickupPoint == source.id and len(c.memory.PickupPoint)>0))
         print('Source: ', str(source.id) + ', requiredCreeps: ' + str(requiredCreeps) + ' num_creeps ' + str(num_creeps))

--- a/harvester.py
+++ b/harvester.py
@@ -486,10 +486,10 @@ def transferEnergyToHauler (creep, target):
         print (str(creep.name) + ' attempted to transfer energy to a nonexisting creep.' )
         del creep.memory.target
     else:
-        print(str(creep.name) + creep.pos.isNearTo(target) + str(target))
+        # print(str(creep.name) + creep.pos.isNearTo(target) + str(target))
         if creep.pos.isNearTo(target):
             result = creep.transfer(target, RESOURCE_ENERGY, _.sum(creep.carry))
-            print(result)
+            # print(result)
             if result == -8:
                 result = creep.transfer(target, RESOURCE_ENERGY, (target.carryCapacity - _.sum(target.carry)))
                 creep.memory.filling = True


### PR DESCRIPTION
The idea for limiting the amount of creeps to a specific source "broke" the number of creeps for a source. It was set = 2 instead of being calculated. One of the main reasons is that walls were counted as viable access points.